### PR TITLE
Update LRMTransportDirectConnect.cs

### DIFF
--- a/UnityProject/Assets/Mirror/Transports/LRM/LRMTransport/LRMTransportDirectConnect.cs
+++ b/UnityProject/Assets/Mirror/Transports/LRM/LRMTransport/LRMTransportDirectConnect.cs
@@ -57,11 +57,7 @@ namespace LightReflectiveMirror
 
                 _isClient = true;
 
-#if MIRROR_40_0_OR_NEWER
                 clientToServerTransport.ClientSend(new System.ArraySegment<byte>(_clientSendBuffer, 0, pos), 0);
-#else
-                clientToServerTransport.ClientSend(0, new System.ArraySegment<byte>(_clientSendBuffer, 0, pos));
-#endif
             }
 
             if (_clientProxy != null)


### PR DESCRIPTION
Remove the compiler symbol wrapping for next Mirror release.
Mirror compiler symbols were culled to start with MIRROR_55_0_OR_NEWER.

![image](https://user-images.githubusercontent.com/9826063/210801786-7077170c-37ed-495c-bd52-3f66c7a85157.png)
