### PR TITLE
Update _appRooms to only include public rooms

### DIFF
--- a/ServerProject-DONT-IMPORT-INTO-UNITY/LRM/Endpoint.cs
+++ b/ServerProject-DONT-IMPORT-INTO-UNITY/LRM/Endpoint.cs
@@ -34,7 +34,14 @@ namespace LightReflectiveMirror.Endpoints
         public static DateTime lastPing = DateTime.Now;
 
         private static List<Room> _rooms { get => Program.instance.GetRooms().Where(x => x.isPublic).ToList(); }
-        private static List<List<Room>> _appRooms { get => Program.instance.GetRooms().GroupBy(x => x.appId).Select(grp => grp.ToList()).ToList(); }
+        private static List<List<Room>> _appRooms 
+        { 
+            get => Program.instance.GetRooms()
+                .Where(x => x.isPublic)
+                .GroupBy(x => x.appId)
+                .Select(grp => grp.ToList())
+                .ToList(); 
+        }
 
         private RelayStats _stats
         {


### PR DESCRIPTION
This pull request updates the `_appRooms` property to only include public rooms. Previously, the `_appRooms` property included all rooms, regardless of whether they were public or private. This change adds a `Where` clause to the `_appRooms` property to filter out private rooms, ensuring that only public rooms are included.